### PR TITLE
Clean up graffiti using CSS selectors

### DIFF
--- a/css/alt.css
+++ b/css/alt.css
@@ -1,15 +1,18 @@
- /* write your override styles here */
+ /* This is how I solved it last night. 
+
+One - I moved this style sheet below or after the paint.css
+Two - I accomplished this without putting div before everything. */
 
 #wall .tag-1 {
   display: none;
 }
 
-#wall div#tag-2 {
+#wall #tag-2 {
   display: none;
 }
 /* div id    class class */
 /* a class of "slick wicked" is really two classes */
-div#wall #tag-3.slick.wicked {
+#wall #tag-3.slick.wicked {
   display: none;
 }
 
@@ -18,17 +21,16 @@ div#wall #tag-3.slick.wicked {
 }
 /* child combiner */
 /* selects the child div of .parent */
-div#wall div.parent #tag-5.slick  {
+#wall .parent > div {
   display: none;
 } 
 
 
 /* I needed to move around the links to the style sheet */
-body div#wall div.parent div:last-child div#tag-6 {
+#wall .parent > div #tag-6 {
   display: none; 
 }
 
-body div#wall div.parent div:first-child > div#tag-7.slick { 
+#wall * { 
   display: none;
 }
-

--- a/index.html
+++ b/index.html
@@ -4,8 +4,10 @@
   <meta charset="UTF-8">
   <title>CSS Graffiti Override</title>
   <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.1/normalize.min.css">
-  <link rel="stylesheet" href="css/cleanup.css">
+  
   <link rel="stylesheet" href="css/paint.css">
+  <!--<link rel="stylesheet" type="text/css" href="css/alt.css">--> <!-- This is how I "solved" the lab.-->
+  <link rel="stylesheet" href="css/cleanup.css">
   <script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.min.js"></script>
 </head>
 <body>


### PR DESCRIPTION
The solution code I used in cleanup.css is exactly the same as the solution code Jonathan Grover used, but the code to follow is what I used last night to complete the lab and can be found in the css file as `alt.css`. I commented it out in `index.html` to demonstrate that both style sheets work but I still don't feel as if my code is the best way of doing things.

```
 /* This is how I solved it last night. 

One - I moved this style sheet below or after the paint.css
Two - I accomplished this without putting div before everything. */

#wall .tag-1 {
  display: none;
}

#wall #tag-2 {
  display: none;
}
/* div id    class class */
/* a class of "slick wicked" is really two classes */
#wall #tag-3.slick.wicked {
  display: none;
}

#wall .parent #tag-4 {
  display: none;
}
/* child combiner */
/* selects the child div of .parent */
#wall .parent > div {
  display: none;
} 


/* I needed to move around the links to the style sheet */
#wall .parent > div #tag-6 {
  display: none; 
}

#wall * { 
  display: none;
}
```

As you can see I left two comments in the first few lines of my code. 

The first was suggested to me when I was seeking help on Stackoverflow, a few of the comments people made were that I needed to put the link to the cleanup.css **after** the paint.css link. I'm not sure if that is considered breaking the rules for this lab but I thought it was a good point.

The second comment is really more of a question. I want to know **why** the method of `body` and `div` proceeding selectors in CSS is more correct. Here is a comparison of the Flatiron solution compared to my solution for `#tag-6`:
Flatiron:

```
body div#wall div.parent div:last-child div#tag-6
```

Mine:

```
#wall .parent > div #tag-6
```

Both work, yet I want to know why `div` needs to be used to such an extent because I don't think the way I solved this lab is the "right" way.
